### PR TITLE
Learning SymbolTables from the content of rules

### DIFF
--- a/parserule/Cargo.toml
+++ b/parserule/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nom = "8.0.0"
+nom = "7.1.3"
 rustfst = "1.1.2"
 anyhow = "1.0.98"
 itertools = "0.14.0"

--- a/parserule/src/ruleparse.rs
+++ b/parserule/src/ruleparse.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, hash::Hash};
 
 use nom::{
     branch::alt,
@@ -6,9 +6,9 @@ use nom::{
     character::complete::{alpha1, char as nom_char, line_ending, none_of, one_of, space0},
     combinator::{map_res, recognize, success, value},
     multi::{many0, many1, separated_list0, separated_list1},
-    sequence::{delimited, pair, preceded, terminated},
+    sequence::{delimited, pair, preceded, terminated, tuple},
+    Err, IResult, Parser,
 };
-use nom::{Err, IResult, Parser};
 use std::char;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -44,12 +44,13 @@ pub struct RewriteRule {
 
 type ParseError<'a> = Err<nom::error::Error<&'a str>>;
 
-fn character(input: &str) -> IResult<&str, RegexAST> {
+fn character(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
     let (input, c) = none_of(" />_()[]-|*+^#:%\\\n\r")(input)?;
-    Ok((input, RegexAST::Char(c)))
+    let syms: HashSet<String> = HashSet::from([c.to_string()]);
+    Ok((input, (RegexAST::Char(c), syms)))
 }
 
-fn uni_esc(input: &str) -> IResult<&str, RegexAST> {
+fn uni_esc(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
     let mut parser = map_res(
         preceded(
             tag("\\u"),
@@ -57,18 +58,20 @@ fn uni_esc(input: &str) -> IResult<&str, RegexAST> {
         ),
         |out: &str| u32::from_str_radix(out, 16),
     );
-
     let (input, num) = parser.parse(input)?;
-    Ok((input, RegexAST::Char(std::char::from_u32(num).unwrap())))
+    let c = std::char::from_u32(num).unwrap();
+    let syms: HashSet<String> = HashSet::from([c.to_string()]);
+    Ok((input, (RegexAST::Char(c), syms)))
 }
 
-fn escape(input: &str) -> IResult<&str, RegexAST> {
+fn escape(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
     let mut parser = preceded(tag("\\"), one_of("\\ /<>_()[]-|*+^#:%"));
     let (input, c) = parser.parse(input)?;
-    Ok((input, RegexAST::Char(c)))
+    let syms: HashSet<String> = HashSet::from([c.to_string()]);
+    Ok((input, (RegexAST::Char(c), syms)))
 }
 
-fn class(input: &str) -> IResult<&str, RegexAST> {
+fn class(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
     let mut parser = delimited(
         nom_char('['),
         many1(alt((escape, uni_esc, character))),
@@ -78,15 +81,15 @@ fn class(input: &str) -> IResult<&str, RegexAST> {
     let strings: Vec<String> = chars
         .iter()
         .filter_map(|node| match node {
-            RegexAST::Char(c) => Some(c.to_string()),
+            (RegexAST::Char(c), _) => Some(c.to_string()),
             _ => None,
         })
         .collect();
     let set: HashSet<String> = strings.into_iter().collect();
-    Ok((input, RegexAST::Class(set)))
+    Ok((input, (RegexAST::Class(set.clone()), set)))
 }
 
-fn complement_class(input: &str) -> IResult<&str, RegexAST> {
+fn complement_class(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
     let mut parser = delimited(
         nom_char('['),
         preceded(nom_char('^'), many1(alt((escape, uni_esc, character)))),
@@ -96,15 +99,15 @@ fn complement_class(input: &str) -> IResult<&str, RegexAST> {
     let strings: Vec<String> = chars
         .iter()
         .filter_map(|node| match node {
-            RegexAST::Char(c) => Some(c.to_string()),
+            (RegexAST::Char(c), _) => Some(c.to_string()),
             _ => None,
         })
         .collect();
     let set: HashSet<String> = strings.into_iter().collect();
-    Ok((input, RegexAST::ClassComplement(set)))
+    Ok((input, (RegexAST::ClassComplement(set.clone()), set)))
 }
 
-fn sequence(input: &str) -> IResult<&str, RegexAST> {
+fn sequence(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
     let mut parser = many1(alt((
         boundary_mark,
         epsilon_mark,
@@ -120,88 +123,110 @@ fn sequence(input: &str) -> IResult<&str, RegexAST> {
         escape,
         character,
     )));
-    let (input, g) = parser.parse(input)?;
-    Ok((input, RegexAST::Group(g)))
+    //let (input, elem:<(RegexAST, HashSet<String>) = parser.parse(input)?;
+    let (input, elems) = parser.parse(input)?;
+    let mut set = HashSet::new();
+    for (_, s) in elems.clone() {
+        set.extend(s.iter().cloned());
+    }
+    let g: Vec<RegexAST> = elems.iter().cloned().map(|(r, _)| r).collect();
+    Ok((input, (RegexAST::Group(g), set)))
 }
 
-fn group(input: &str) -> IResult<&str, RegexAST> {
+fn group(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
     let mut parser = delimited(nom_char('('), sequence, nom_char(')'));
     let (input, g) = parser.parse(input)?;
     Ok((input, g))
 }
 
-pub fn characters(input: &str) -> IResult<&str, RegexAST> {
-    let (input, g) = many1(character).parse(input)?;
-    Ok((input, RegexAST::Group(g)))
+pub fn characters(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
+    let (input, elems) = many1(character).parse(input)?;
+    let mut set = HashSet::new();
+    for (_, s) in &elems {
+        set.extend(s.iter().cloned());
+    }
+    let re = elems.into_iter().map(|(r, _)| r).collect();
+    Ok((input, (RegexAST::Group(re), set)))
 }
 
-fn regex(input: &str) -> IResult<&str, RegexAST> {
-    let (input, g) = alt((sequence, success(RegexAST::Epsilon))).parse(input)?;
-    Ok((input, g))
+fn regex(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
+    let (input, (re, set)) = alt((sequence, rp_success)).parse(input)?;
+    Ok((input, (re, set)))
 }
 
-fn disjunction(input: &str) -> IResult<&str, RegexAST> {
-    let (input, g) = delimited(
+fn rp_success(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
+    let (input, re) = success(RegexAST::Epsilon).parse(input)?;
+    Ok((input, (re, HashSet::new())))
+}
+
+fn disjunction(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
+    let (input, elems) = delimited(
         nom_char('('),
         separated_list1(nom_char('|'), sequence),
         nom_char(')'),
     )
     .parse(input)?;
-    Ok((input, RegexAST::Disjunction(g)))
+    let re: Vec<RegexAST> = elems.clone().into_iter().map(|(r, _)| r).collect();
+    let mut set = HashSet::new();
+    for (_, s) in elems {
+        set.extend(s);
+    }
+    Ok((input, (RegexAST::Disjunction(re), set)))
 }
 
-fn plus(input: &str) -> IResult<&str, RegexAST> {
-    let (input, g) =
+fn plus(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
+    let (input, (re, set)) =
         terminated(alt((group, character, class, disjunction)), nom_char('+')).parse(input)?;
-    Ok((input, RegexAST::Plus(Box::new(g))))
+    Ok((input, (RegexAST::Plus(Box::new(re)), set)))
 }
 
-fn star(input: &str) -> IResult<&str, RegexAST> {
-    let (input, g) =
+fn star(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
+    let (input, (re, set)) =
         terminated(alt((group, character, class, disjunction)), nom_char('*')).parse(input)?;
-    Ok((input, RegexAST::Star(Box::new(g))))
+    Ok((input, (RegexAST::Star(Box::new(re)), set)))
 }
 
-fn option(input: &str) -> IResult<&str, RegexAST> {
-    let (input, g) =
+fn option(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
+    let (input, (re, set)) =
         terminated(alt((group, character, class, disjunction)), nom_char('?')).parse(input)?;
-    Ok((input, RegexAST::Option(Box::new(g))))
+    Ok((input, (RegexAST::Option(Box::new(re)), set)))
 }
 
-fn mac(input: &str) -> IResult<&str, RegexAST> {
+fn mac(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
     let (input, m) = delimited(tag("::"), alpha1, tag("::")).parse(input)?;
-    Ok((input, RegexAST::Macro(m.to_string())))
+    Ok((input, (RegexAST::Macro(m.to_string()), HashSet::new())))
 }
 
-fn boundary_mark(input: &str) -> IResult<&str, RegexAST> {
-    let (input, m) = value(RegexAST::Boundary, tag("#")).parse(input)?;
-    Ok((input, m))
+fn boundary_mark(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
+    let (input, re) = value(RegexAST::Boundary, tag("#")).parse(input)?;
+    Ok((input, (re, HashSet::new())))
 }
 
-fn epsilon_mark(input: &str) -> IResult<&str, RegexAST> {
-    let (input, m) = value(RegexAST::Epsilon, tag("0")).parse(input)?;
-    Ok((input, m))
+fn epsilon_mark(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
+    let (input, re) = value(RegexAST::Epsilon, tag("0")).parse(input)?;
+    Ok((input, (re, HashSet::new())))
 }
 
-fn comment(input: &str) -> IResult<&str, RegexAST> {
+fn comment(input: &str) -> IResult<&str, (RegexAST, HashSet<String>)> {
     value(
-        RegexAST::Comment,
+        (RegexAST::Comment, HashSet::new()),
         pair(nom_char('%'), many0(none_of("\n\r"))),
     )
     .parse(input)
 }
 
-fn re_mac_def(input: &str) -> IResult<&str, (String, RegexAST)> {
-    let (input, (_, name, _, _, _, re_group)) = (
+fn re_mac_def(input: &str) -> IResult<&str, (String, RegexAST, HashSet<String>)> {
+    let (input, (_, name, _, _, _, def)) = tuple((
         space0,
         delimited(tag("::"), alpha1, tag("::")),
         space0,
         tag("="),
         space0,
         regex,
-    )
-        .parse(input)?;
-    Ok((input, (name.to_string(), re_group)))
+    ))(input)?;
+
+    let (re, set) = def;
+    Ok((input, (name.to_string(), re, set)))
 }
 
 // pub fn rule(input: &str) -> IResult<&str, RewriteRule> {
@@ -227,8 +252,11 @@ fn re_mac_def(input: &str) -> IResult<&str, (String, RegexAST)> {
 //     ))
 // }
 
-pub fn rule(input: &str) -> IResult<&str, RewriteRule> {
-    let (input, (source, _, target, _, left, _, right, _)) = (
+pub fn rule(input: &str) -> IResult<&str, (RewriteRule, HashSet<String>)> {
+    let (
+        input,
+        ((source, src_set), _, (target, tgt_set), _, (left, left_set), _, (right, right_set), _),
+    ) = tuple((
         regex,
         delimited(space0, tag("->"), space0),
         regex,
@@ -237,35 +265,53 @@ pub fn rule(input: &str) -> IResult<&str, RewriteRule> {
         delimited(space0, tag("_"), space0),
         regex,
         space0,
-    )
-        .parse(input)?;
+    ))
+    .parse(input)?;
+    let mut set = HashSet::new();
+    set.extend(src_set);
+    set.extend(tgt_set);
+    set.extend(left_set);
+    set.extend(right_set);
     Ok((
         input,
-        RewriteRule {
-            source,
-            target,
-            left,
-            right,
-        },
+        (
+            RewriteRule {
+                source,
+                target,
+                left,
+                right,
+            },
+            set,
+        ),
     ))
 }
 
-pub fn rule_no_env(input: &str) -> IResult<&str, RewriteRule> {
-    let (input, (source, _, target)) =
-        (regex, delimited(space0, tag("->"), space0), regex).parse(input)?;
+pub fn rule_no_env(input: &str) -> IResult<&str, (RewriteRule, HashSet<String>)> {
+    let (input, ((source, src_set), _, (target, tgt_set))) =
+        tuple((regex, delimited(space0, tag("->"), space0), regex)).parse(input)?;
+    let mut set = HashSet::new();
+    set.extend(src_set);
+    set.extend(tgt_set);
+
     Ok((
         input,
-        RewriteRule {
-            source,
-            target,
-            left: RegexAST::Epsilon,
-            right: RegexAST::Epsilon,
-        },
+        (
+            RewriteRule {
+                source,
+                target,
+                left: RegexAST::Epsilon,
+                right: RegexAST::Epsilon,
+            },
+            set,
+        ),
     ))
 }
 
-pub fn rule_with_comment(input: &str) -> IResult<&str, RewriteRule> {
-    let (input, (source, _, target, _, left, _, right, _, _)) = (
+pub fn rule_with_comment(input: &str) -> IResult<&str, (RewriteRule, HashSet<String>)> {
+    let (
+        input,
+        ((source, src_set), _, (target, tgt_set), _, (left, left_set), _, (right, right_set), _, _),
+    ) = tuple((
         regex,
         delimited(space0, tag("->"), space0),
         regex,
@@ -275,34 +321,42 @@ pub fn rule_with_comment(input: &str) -> IResult<&str, RewriteRule> {
         regex,
         space0,
         comment,
-    )
-        .parse(input)?;
+    ))
+    .parse(input)?;
+    let mut set = HashSet::new();
+    set.extend(src_set);
+    set.extend(tgt_set);
+    set.extend(left_set);
+    set.extend(right_set);
     Ok((
         input,
-        RewriteRule {
-            left,
-            right,
-            source,
-            target,
-        },
+        (
+            RewriteRule {
+                source,
+                target,
+                left,
+                right,
+            },
+            set,
+        ),
     ))
 }
 
-fn comment_statement(input: &str) -> IResult<&str, Statement> {
-    value(Statement::Comment, comment).parse(input)
+fn comment_statement(input: &str) -> IResult<&str, (Statement, HashSet<String>)> {
+    value((Statement::Comment, HashSet::new()), comment).parse(input)
 }
 
-fn rule_statement(input: &str) -> IResult<&str, Statement> {
-    let (input, r) = alt((rule, rule_no_env, rule_with_comment)).parse(input)?;
-    Ok((input, Statement::Rule(r)))
+fn rule_statement(input: &str) -> IResult<&str, (Statement, HashSet<String>)> {
+    let (input, (rr, set)) = alt((rule, rule_no_env, rule_with_comment)).parse(input)?;
+    Ok((input, (Statement::Rule(rr), set)))
 }
 
-fn macro_statement(input: &str) -> IResult<&str, Statement> {
-    let (input, m) = re_mac_def(input)?;
-    Ok((input, Statement::MacroDef(m)))
+fn macro_statement(input: &str) -> IResult<&str, (Statement, HashSet<String>)> {
+    let (input, (name, re, set)) = re_mac_def(input)?;
+    Ok((input, (Statement::MacroDef((name, re)), set)))
 }
 
-pub fn parse_script(input: &str) -> Result<Vec<Statement>, ParseError> {
+pub fn parse_script(input: &str) -> IResult<&str, (Vec<Statement>, HashSet<String>)> {
     let mut parser = pair(
         separated_list0(
             many1(line_ending),
@@ -311,7 +365,13 @@ pub fn parse_script(input: &str) -> Result<Vec<Statement>, ParseError> {
         many0(line_ending),
     );
 
-    parser.parse(input).map(|(_, (statements, _))| statements)
+    let (input, (states_and_sets, _)) = parser.parse(input)?;
+    let mut set: HashSet<String> = HashSet::new();
+    for (_, s) in states_and_sets.clone().iter() {
+        set.extend(s.clone());
+    }
+    let statements: Vec<Statement> = states_and_sets.iter().map(|(t, _)| t.clone()).collect();
+    Ok((input, (statements, set)))
 }
 
 #[cfg(test)]
@@ -319,357 +379,372 @@ mod tests {
 
     use super::*;
 
+macro_rules! hashset_str {
+    ($($val:expr),* $(,)?) => {{
+        let mut set = std::collections::HashSet::new();
+        $( set.insert(String::from($val)); )*
+        set
+    }};
+}
+
     #[test]
     fn test_character() {
-        assert_eq!(character("abc"), Ok(("bc", RegexAST::Char('a'))));
-    }
-
-    #[test]
-    fn test_uni_esc() {
-        assert_eq!(uni_esc(r#"\u014B"#), Ok(("", RegexAST::Char('ŋ'))));
-    }
-
-    #[test]
-    fn test_class() {
         assert_eq!(
-            class("[abc]"),
-            Ok((
-                "",
-                RegexAST::Class(
-                    vec!["a", "b", "c"]
-                        .into_iter()
-                        .map(|s| s.to_string())
-                        .collect()
-                )
-            ))
+            character("abc"),
+            Ok(("bc", (RegexAST::Char('a'), hashset_str!("a"))))
         );
     }
 
-    #[test]
-    fn test_complement_class() {
-        assert_eq!(
-            complement_class("[^abc]"),
-            Ok((
-                "",
-                RegexAST::ClassComplement(
-                    vec!["a", "b", "c"]
-                        .into_iter()
-                        .map(|s| s.to_string())
-                        .collect()
-                )
-            ))
-        );
-    }
+    /*
 
-    #[test]
-    fn test_sequence4() {
-        debug_assert_eq!(
-            sequence("a"),
-            Ok(("", RegexAST::Group(vec![RegexAST::Char('a')])))
-        );
-    }
+       #[test]
+       fn test_uni_esc() {
+           assert_eq!(uni_esc(r#"\u014B"#), Ok(("", RegexAST::Char('ŋ'))));
+       }
 
-    #[test]
-    fn test_group3() {
-        debug_assert_eq!(
-            group("(a)"),
-            Ok(("", RegexAST::Group(vec![RegexAST::Char('a')])))
-        );
-    }
+       #[test]
+       fn test_class() {
+           assert_eq!(
+               class("[abc]"),
+               Ok((
+                   "",
+                   RegexAST::Class(
+                       vec!["a", "b", "c"]
+                           .into_iter()
+                           .map(|s| s.to_string())
+                           .collect()
+                   )
+               ))
+           );
+       }
 
-    #[test]
-    fn test_group2() {
-        debug_assert_eq!(
-            group("(a[def])"),
-            Ok((
-                "",
-                RegexAST::Group(vec![
-                    RegexAST::Char('a'),
-                    RegexAST::Class(
-                        vec!["d", "e", "f"]
-                            .into_iter()
-                            .map(|s| s.to_string())
-                            .collect()
-                    )
-                ])
-            ))
-        );
-    }
+       #[test]
+       fn test_complement_class() {
+           assert_eq!(
+               complement_class("[^abc]"),
+               Ok((
+                   "",
+                   RegexAST::ClassComplement(
+                       vec!["a", "b", "c"]
+                           .into_iter()
+                           .map(|s| s.to_string())
+                           .collect()
+                   )
+               ))
+           );
+       }
 
-    #[test]
-    fn test_regex1() {
-        debug_assert_eq!(
-            regex("a"),
-            Ok(("", RegexAST::Group(vec![RegexAST::Char('a')])))
-        );
-    }
+       #[test]
+       fn test_sequence4() {
+           debug_assert_eq!(
+               sequence("a"),
+               Ok(("", RegexAST::Group(vec![RegexAST::Char('a')])))
+           );
+       }
 
-    #[test]
-    fn test_regex2() {
-        debug_assert_eq!(regex(""), Ok(("", RegexAST::Epsilon)));
-    }
+       #[test]
+       fn test_group3() {
+           debug_assert_eq!(
+               group("(a)"),
+               Ok(("", RegexAST::Group(vec![RegexAST::Char('a')])))
+           );
+       }
 
-    #[test]
-    fn test_plus() {
-        debug_assert_eq!(
-            plus("a+"),
-            Ok(("", RegexAST::Plus(Box::new(RegexAST::Char('a')))))
-        )
-    }
+       #[test]
+       fn test_group2() {
+           debug_assert_eq!(
+               group("(a[def])"),
+               Ok((
+                   "",
+                   RegexAST::Group(vec![
+                       RegexAST::Char('a'),
+                       RegexAST::Class(
+                           vec!["d", "e", "f"]
+                               .into_iter()
+                               .map(|s| s.to_string())
+                               .collect()
+                       )
+                   ])
+               ))
+           );
+       }
 
-    #[test]
-    fn test_regex_with_plus1() {
-        debug_assert_eq!(
-            regex("a+b"),
-            Ok((
-                "",
-                RegexAST::Group(vec![
-                    RegexAST::Plus(Box::new(RegexAST::Char('a'))),
-                    RegexAST::Char('b'),
-                ])
-            ))
-        );
-    }
+       #[test]
+       fn test_regex1() {
+           debug_assert_eq!(
+               regex("a"),
+               Ok(("", RegexAST::Group(vec![RegexAST::Char('a')])))
+           );
+       }
 
-    #[test]
-    fn test_regex_with_plus_class() {
-        debug_assert_eq!(
-            regex("[ab]+"),
-            Ok((
-                "",
-                RegexAST::Group(vec![RegexAST::Plus(Box::new(RegexAST::Class(
-                    vec!["a", "b"].into_iter().map(|s| s.to_string()).collect()
-                )))])
-            ))
-        )
-    }
+       #[test]
+       fn test_regex2() {
+           debug_assert_eq!(regex(""), Ok(("", RegexAST::Epsilon)));
+       }
 
-    #[test]
-    fn test_regex_with_plus_disjunction() {
-        debug_assert_eq!(
-            regex("(c|d)+"),
-            Ok((
-                "",
-                RegexAST::Group(vec![RegexAST::Plus(Box::new(RegexAST::Disjunction(vec![
-                    RegexAST::Group(vec![RegexAST::Char('c')]),
-                    RegexAST::Group(vec![RegexAST::Char('d')])
-                ])))])
-            ))
-        );
-    }
+       #[test]
+       fn test_plus() {
+           debug_assert_eq!(
+               plus("a+"),
+               Ok(("", RegexAST::Plus(Box::new(RegexAST::Char('a')))))
+           )
+       }
 
-    #[test]
-    fn test_regex_with_star() {
-        debug_assert_eq!(
-            regex("a*b"),
-            Ok((
-                "",
-                RegexAST::Group(vec![
-                    RegexAST::Star(Box::new(RegexAST::Char('a'))),
-                    RegexAST::Char('b'),
-                ])
-            ))
-        );
-    }
+       #[test]
+       fn test_regex_with_plus1() {
+           debug_assert_eq!(
+               regex("a+b"),
+               Ok((
+                   "",
+                   RegexAST::Group(vec![
+                       RegexAST::Plus(Box::new(RegexAST::Char('a'))),
+                       RegexAST::Char('b'),
+                   ])
+               ))
+           );
+       }
 
-    #[test]
-    fn test_regex_with_star_class() {
-        debug_assert_eq!(
-            regex("[ab]*"),
-            Ok((
-                "",
-                RegexAST::Group(vec![RegexAST::Star(Box::new(RegexAST::Class(
-                    vec!["a", "b"].into_iter().map(|s| s.to_string()).collect()
-                )))])
-            ))
-        );
-    }
+       #[test]
+       fn test_regex_with_plus_class() {
+           debug_assert_eq!(
+               regex("[ab]+"),
+               Ok((
+                   "",
+                   RegexAST::Group(vec![RegexAST::Plus(Box::new(RegexAST::Class(
+                       vec!["a", "b"].into_iter().map(|s| s.to_string()).collect()
+                   )))])
+               ))
+           )
+       }
 
-    #[test]
-    fn test_regex_with_star_disjunction() {
-        debug_assert_eq!(
-            regex("(c|d)*"),
-            Ok((
-                "",
-                RegexAST::Group(vec![RegexAST::Star(Box::new(RegexAST::Disjunction(vec![
-                    RegexAST::Group(vec![RegexAST::Char('c')]),
-                    RegexAST::Group(vec![RegexAST::Char('d')])
-                ])))])
-            ))
-        );
-    }
+       #[test]
+       fn test_regex_with_plus_disjunction() {
+           debug_assert_eq!(
+               regex("(c|d)+"),
+               Ok((
+                   "",
+                   RegexAST::Group(vec![RegexAST::Plus(Box::new(RegexAST::Disjunction(vec![
+                       RegexAST::Group(vec![RegexAST::Char('c')]),
+                       RegexAST::Group(vec![RegexAST::Char('d')])
+                   ])))])
+               ))
+           );
+       }
 
-    #[test]
-    fn test_mac() {
-        debug_assert_eq!(
-            mac("::macro::"),
-            Ok(("", RegexAST::Macro("macro".to_string())))
-        );
-    }
+       #[test]
+       fn test_regex_with_star() {
+           debug_assert_eq!(
+               regex("a*b"),
+               Ok((
+                   "",
+                   RegexAST::Group(vec![
+                       RegexAST::Star(Box::new(RegexAST::Char('a'))),
+                       RegexAST::Char('b'),
+                   ])
+               ))
+           );
+       }
 
-    #[test]
-    fn test_re_mac_def() {
-        debug_assert_eq!(
-            re_mac_def("::abc:: = (d|e)"),
-            Ok((
-                "",
-                (
-                    "abc".to_string(),
-                    RegexAST::Group(vec![RegexAST::Disjunction(vec![
-                        RegexAST::Group(vec!(RegexAST::Char('d'))),
-                        RegexAST::Group(vec!(RegexAST::Char('e'))),
-                    ])])
-                )
-            ))
-        );
-    }
+       #[test]
+       fn test_regex_with_star_class() {
+           debug_assert_eq!(
+               regex("[ab]*"),
+               Ok((
+                   "",
+                   RegexAST::Group(vec![RegexAST::Star(Box::new(RegexAST::Class(
+                       vec!["a", "b"].into_iter().map(|s| s.to_string()).collect()
+                   )))])
+               ))
+           );
+       }
 
-    #[test]
-    fn test_comment() {
-        debug_assert_eq!(comment("% Comment"), Ok(("", RegexAST::Comment,)))
-    }
+       #[test]
+       fn test_regex_with_star_disjunction() {
+           debug_assert_eq!(
+               regex("(c|d)*"),
+               Ok((
+                   "",
+                   RegexAST::Group(vec![RegexAST::Star(Box::new(RegexAST::Disjunction(vec![
+                       RegexAST::Group(vec![RegexAST::Char('c')]),
+                       RegexAST::Group(vec![RegexAST::Char('d')])
+                   ])))])
+               ))
+           );
+       }
 
-    #[test]
-    fn test_rule_no_env() {
-        debug_assert_eq!(
-            rule_no_env("a -> b"),
-            Ok((
-                "",
-                RewriteRule {
-                    left: RegexAST::Epsilon,
-                    right: RegexAST::Epsilon,
-                    source: RegexAST::Group(vec![RegexAST::Char('a')]),
-                    target: RegexAST::Group(vec![RegexAST::Char('b')]),
-                }
-            ))
-        );
-    }
+       #[test]
+       fn test_mac() {
+           debug_assert_eq!(
+               mac("::macro::"),
+               Ok(("", RegexAST::Macro("macro".to_string())))
+           );
+       }
 
-    #[test]
-    fn test_rule() {
-        debug_assert_eq!(
-            rule("a -> b / c _ d"),
-            Ok((
-                "",
-                RewriteRule {
-                    left: RegexAST::Group(vec![RegexAST::Char('c')]),
-                    right: RegexAST::Group(vec![RegexAST::Char('d')]),
-                    source: RegexAST::Group(vec![RegexAST::Char('a')]),
-                    target: RegexAST::Group(vec![RegexAST::Char('b')]),
-                }
-            ))
-        );
-    }
+       #[test]
+       fn test_re_mac_def() {
+           debug_assert_eq!(
+               re_mac_def("::abc:: = (d|e)"),
+               Ok((
+                   "",
+                   (
+                       "abc".to_string(),
+                       RegexAST::Group(vec![RegexAST::Disjunction(vec![
+                           RegexAST::Group(vec!(RegexAST::Char('d'))),
+                           RegexAST::Group(vec!(RegexAST::Char('e'))),
+                       ])])
+                   )
+               ))
+           );
+       }
 
-    #[test]
-    fn test_rule2() {
-        debug_assert_eq!(
-            rule("b -> p / _ #"),
-            Ok((
-                "",
-                RewriteRule {
-                    left: RegexAST::Epsilon,
-                    right: RegexAST::Group(vec![RegexAST::Boundary]),
-                    source: RegexAST::Group(vec![RegexAST::Char('b')]),
-                    target: RegexAST::Group(vec![RegexAST::Char('p')]),
-                }
-            ))
-        )
-    }
+       #[test]
+       fn test_comment() {
+           debug_assert_eq!(comment("% Comment"), Ok(("", RegexAST::Comment,)))
+       }
 
-    #[test]
-    fn test_rule3() {
-        debug_assert_eq!(
-            rule("0 -> 0 /  _ "),
-            Ok((
-                "",
-                RewriteRule {
-                    left: RegexAST::Epsilon,
-                    right: RegexAST::Epsilon,
-                    source: RegexAST::Group(vec![RegexAST::Epsilon]),
-                    target: RegexAST::Group(vec![RegexAST::Epsilon]),
-                }
-            ))
-        )
-    }
+       #[test]
+       fn test_rule_no_env() {
+           debug_assert_eq!(
+               rule_no_env("a -> b"),
+               Ok((
+                   "",
+                   RewriteRule {
+                       left: RegexAST::Epsilon,
+                       right: RegexAST::Epsilon,
+                       source: RegexAST::Group(vec![RegexAST::Char('a')]),
+                       target: RegexAST::Group(vec![RegexAST::Char('b')]),
+                   }
+               ))
+           );
+       }
 
-    #[test]
-    fn test_rule_with_comment() {
-        debug_assert_eq!(
-            rule_with_comment("a -> b / c _ d % Comment"),
-            Ok((
-                "",
-                RewriteRule {
-                    left: RegexAST::Group(vec![RegexAST::Char('c')]),
-                    right: RegexAST::Group(vec![RegexAST::Char('d')]),
-                    source: RegexAST::Group(vec![RegexAST::Char('a')]),
-                    target: RegexAST::Group(vec![RegexAST::Char('b')]),
-                }
-            ))
-        );
-    }
+       #[test]
+       fn test_rule() {
+           debug_assert_eq!(
+               rule("a -> b / c _ d"),
+               Ok((
+                   "",
+                   RewriteRule {
+                       left: RegexAST::Group(vec![RegexAST::Char('c')]),
+                       right: RegexAST::Group(vec![RegexAST::Char('d')]),
+                       source: RegexAST::Group(vec![RegexAST::Char('a')]),
+                       target: RegexAST::Group(vec![RegexAST::Char('b')]),
+                   }
+               ))
+           );
+       }
 
-    #[test]
-    fn test_multiple_rules() {
-        debug_assert_eq!(
-            parse_script("a -> b / c _ d\nb -> p / _ #"),
-            Ok(vec![
-                Statement::Rule(RewriteRule {
-                    left: RegexAST::Group(vec![RegexAST::Char('c')]),
-                    right: RegexAST::Group(vec![RegexAST::Char('d')]),
-                    source: RegexAST::Group(vec![RegexAST::Char('a')]),
-                    target: RegexAST::Group(vec![RegexAST::Char('b')]),
-                }),
-                Statement::Rule(RewriteRule {
-                    left: RegexAST::Epsilon,
-                    right: RegexAST::Group(vec![RegexAST::Boundary]),
-                    source: RegexAST::Group(vec![RegexAST::Char('b')]),
-                    target: RegexAST::Group(vec![RegexAST::Char('p')]),
-                })
-            ])
-        );
-    }
+       #[test]
+       fn test_rule2() {
+           debug_assert_eq!(
+               rule("b -> p / _ #"),
+               Ok((
+                   "",
+                   RewriteRule {
+                       left: RegexAST::Epsilon,
+                       right: RegexAST::Group(vec![RegexAST::Boundary]),
+                       source: RegexAST::Group(vec![RegexAST::Char('b')]),
+                       target: RegexAST::Group(vec![RegexAST::Char('p')]),
+                   }
+               ))
+           )
+       }
 
-    #[test]
-    fn test_multiple_rules_alt_newline() {
-        debug_assert_eq!(
-            parse_script("a -> b / c _ d\r\nb -> p / _ #"),
-            Ok(vec![
-                Statement::Rule(RewriteRule {
-                    left: RegexAST::Group(vec![RegexAST::Char('c')]),
-                    right: RegexAST::Group(vec![RegexAST::Char('d')]),
-                    source: RegexAST::Group(vec![RegexAST::Char('a')]),
-                    target: RegexAST::Group(vec![RegexAST::Char('b')]),
-                }),
-                Statement::Rule(RewriteRule {
-                    left: RegexAST::Epsilon,
-                    right: RegexAST::Group(vec![RegexAST::Boundary]),
-                    source: RegexAST::Group(vec![RegexAST::Char('b')]),
-                    target: RegexAST::Group(vec![RegexAST::Char('p')]),
-                })
-            ])
-        );
-    }
+       #[test]
+       fn test_rule3() {
+           debug_assert_eq!(
+               rule("0 -> 0 /  _ "),
+               Ok((
+                   "",
+                   RewriteRule {
+                       left: RegexAST::Epsilon,
+                       right: RegexAST::Epsilon,
+                       source: RegexAST::Group(vec![RegexAST::Epsilon]),
+                       target: RegexAST::Group(vec![RegexAST::Epsilon]),
+                   }
+               ))
+           )
+       }
 
-    #[test]
-    fn test_rule_and_macro() {
-        debug_assert_eq!(
-            parse_script("::abc:: = (d|e)\na -> b / c _ d"),
-            Ok(vec![
-                Statement::MacroDef((
-                    "abc".to_string(),
-                    RegexAST::Group(vec![RegexAST::Disjunction(vec![
-                        RegexAST::Group(vec!(RegexAST::Char('d'))),
-                        RegexAST::Group(vec!(RegexAST::Char('e'))),
-                    ])])
-                )),
-                Statement::Rule(RewriteRule {
-                    left: RegexAST::Group(vec![RegexAST::Char('c')]),
-                    right: RegexAST::Group(vec![RegexAST::Char('d')]),
-                    source: RegexAST::Group(vec![RegexAST::Char('a')]),
-                    target: RegexAST::Group(vec![RegexAST::Char('b')]),
-                })
-            ])
-        );
-    }
+       #[test]
+       fn test_rule_with_comment() {
+           debug_assert_eq!(
+               rule_with_comment("a -> b / c _ d % Comment"),
+               Ok((
+                   "",
+                   RewriteRule {
+                       left: RegexAST::Group(vec![RegexAST::Char('c')]),
+                       right: RegexAST::Group(vec![RegexAST::Char('d')]),
+                       source: RegexAST::Group(vec![RegexAST::Char('a')]),
+                       target: RegexAST::Group(vec![RegexAST::Char('b')]),
+                   }
+               ))
+           );
+       }
+
+       #[test]
+       fn test_multiple_rules() {
+           debug_assert_eq!(
+               parse_script("a -> b / c _ d\nb -> p / _ #"),
+               Ok(vec![
+                   Statement::Rule(RewriteRule {
+                       left: RegexAST::Group(vec![RegexAST::Char('c')]),
+                       right: RegexAST::Group(vec![RegexAST::Char('d')]),
+                       source: RegexAST::Group(vec![RegexAST::Char('a')]),
+                       target: RegexAST::Group(vec![RegexAST::Char('b')]),
+                   }),
+                   Statement::Rule(RewriteRule {
+                       left: RegexAST::Epsilon,
+                       right: RegexAST::Group(vec![RegexAST::Boundary]),
+                       source: RegexAST::Group(vec![RegexAST::Char('b')]),
+                       target: RegexAST::Group(vec![RegexAST::Char('p')]),
+                   })
+               ])
+           );
+       }
+
+       #[test]
+       fn test_multiple_rules_alt_newline() {
+           debug_assert_eq!(
+               parse_script("a -> b / c _ d\r\nb -> p / _ #"),
+               Ok(vec![
+                   Statement::Rule(RewriteRule {
+                       left: RegexAST::Group(vec![RegexAST::Char('c')]),
+                       right: RegexAST::Group(vec![RegexAST::Char('d')]),
+                       source: RegexAST::Group(vec![RegexAST::Char('a')]),
+                       target: RegexAST::Group(vec![RegexAST::Char('b')]),
+                   }),
+                   Statement::Rule(RewriteRule {
+                       left: RegexAST::Epsilon,
+                       right: RegexAST::Group(vec![RegexAST::Boundary]),
+                       source: RegexAST::Group(vec![RegexAST::Char('b')]),
+                       target: RegexAST::Group(vec![RegexAST::Char('p')]),
+                   })
+               ])
+           );
+       }
+
+       #[test]
+       fn test_rule_and_macro() {
+           debug_assert_eq!(
+               parse_script("::abc:: = (d|e)\na -> b / c _ d"),
+               Ok(vec![
+                   Statement::MacroDef((
+                       "abc".to_string(),
+                       RegexAST::Group(vec![RegexAST::Disjunction(vec![
+                           RegexAST::Group(vec!(RegexAST::Char('d'))),
+                           RegexAST::Group(vec!(RegexAST::Char('e'))),
+                       ])])
+                   )),
+                   Statement::Rule(RewriteRule {
+                       left: RegexAST::Group(vec![RegexAST::Char('c')]),
+                       right: RegexAST::Group(vec![RegexAST::Char('d')]),
+                       source: RegexAST::Group(vec![RegexAST::Char('a')]),
+                       target: RegexAST::Group(vec![RegexAST::Char('b')]),
+                   })
+               ])
+           );
+       }
+
+    */
 }


### PR DESCRIPTION
These are changes designed so that SymbolTables include all and only the symbols need for a language. It must be coupled with equivalent functionality for the mapping tables (to be written).