### PR TITLE
Fix rustfst dependency conflict by creating a workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+members = [
+    "m2mfstaligner",
+    "parserule",
+    "rsepitran",
+]
+
+# Specify a consistent version of rustfst for all crates
+[workspace.dependencies]
+rustfst = "1.1.2"  # Use the newer version
+anyhow = "1.0.98"

--- a/m2mfstaligner/Cargo.toml
+++ b/m2mfstaligner/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.68"
-rustfst = "0.11.6"
+anyhow.workspace = true
+rustfst.workspace = true
 string-join = "0.1.2"
 csv = "1.1"
 unicode-segmentation = "1.10.1"

--- a/parserule/Cargo.toml
+++ b/parserule/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/lib.rs"
 [dependencies]
 # Downgraded from 8.0.0 to 7.1.3 for compatibility with symbol learning features
 nom = "7.1.3"
-rustfst = "1.1.2"
-anyhow = "1.0.98"
+rustfst.workspace = true
+anyhow.workspace = true
 itertools = "0.14.0"
 csv = "1.3"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Problem

When trying to build the project with `cargo build`, the compiler complains about `HashMap`, `Arc`, and `VectorFst` being defined multiple times. This issue occurs because different crates in the project (`m2mfstaligner` and `parserule`) are using different versions of the `rustfst` dependency (0.11.6 vs 1.1.2).

## Solution

This PR fixes the issue by:

1. Creating a workspace Cargo.toml file at the root of the project to manage dependencies consistently across all crates
2. Specifying a consistent version of rustfst (1.1.2, the newer version) in the workspace dependencies
3. Updating the Cargo.toml files for both m2mfstaligner and parserule to use the workspace dependencies using the `.workspace = true` syntax

This ensures that all crates in the workspace use the same version of rustfst, which resolves the multiple definition errors for HashMap, Arc, and VectorFst.

## Changes

- Added a new root-level `Cargo.toml` with workspace configuration
- Updated `m2mfstaligner/Cargo.toml` to use workspace dependencies
- Updated `parserule/Cargo.toml` to use workspace dependencies

@dmort27 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b289e52865aa45ceb71fd51ba543ddc6)